### PR TITLE
Add functionality to write time series

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,51 @@ Supported formats include:
 )
 - [USC](https://strongmotioncenter.org/vdc/USC_Vol1Format.txt)
 
-#### Use
+### Use
 getpgm [-h] -c COMPONENTS [COMPONENTS ...] -m MEASUREMENTS
-              [MEASUREMENTS ...]
-              input_source output_directory format
+              [MEASUREMENTS ...] [-t] [-p]
+              input_source output_directory
+
+Get requested PGM values.
+
+
+#### Positional arguments
+
+  input_source:          The directory of all input files.
+
+  output_directory:      The directory of all output files.
+
+#### Optional arguments
+
+  -h, --help:            show this help message and exit
+
+  -c COMPONENTS [COMPONENTS ...], --components COMPONENTS [COMPONENTS ...]:
+                        The IMC parameters to get.
+
+
+  -m MEASUREMENTS [MEASUREMENTS ...], --measurements MEASUREMENTS [MEASUREMENTS ...]:
+                        The IMT parameters to get.
+
+
+  -t, --timeseries:      Writes out the uncorrected time series for each
+                        station in miniseed.
+
+
+  -p, --parametric:      Writes out the parametric data for each station.
+
+#### PGM Parameters
+Available IMTs:
+- pga
+- sa
+- pgv
+
+Available IMCs:
+- greater_of_two_horizontals
+- channels
+- gmrotd
+
+#### For parameters with specific percentiles or periods, append the number on the end of the parameter string.
+
+Example spectral amplitude: sa1.0
+
+Example geometric mean rotation: gmrotd50

--- a/bin/getpgm
+++ b/bin/getpgm
@@ -40,6 +40,10 @@ def main(args):
     for station in event.stations:
         station_table = event.get_station_dataframe(station)
         event.write_station_table(station_table, output_directory, station)
+    if args.parametric is not None:
+        event.write_parametric(output_directory)
+    if args.timeseries is not None:
+        event.write_timeseries(output_directory, 'MSEED', include_json=False)
 
 def _get_parser():
     """
@@ -80,6 +84,10 @@ def _get_parser():
             default=[], help='The IMC parameters to get.', required=True)
     parser.add_argument('-m', '--measurements', nargs='+', dest='measurements',
             default=[], help='The IMT parameters to get.', required=True)
+    parser.add_argument('-t', '--timeseries', action="store_true",
+            help="Writes out the uncorrected time series for each station in miniseed.")
+    parser.add_argument('-p', '--parametric', action="store_true",
+            help="Writes out the parametric data for each station")
     return parser
 
 

--- a/tests/bin/getpgm_test.py
+++ b/tests/bin/getpgm_test.py
@@ -39,8 +39,8 @@ def test_imc_imt():
     imc = '-c channels'
     tmpdir = tempfile.mkdtemp()
     try:
-        cmd = '%s %s %s %s %s' % (getpgm, input_directory,
-                tmpdir, imc, imt)
+        cmd = '%s %s %s %s %s -t -p' % (getpgm,
+                input_directory, tmpdir, imc, imt)
         res, stdout, stderr = get_command_output(cmd)
         if not res:
             raise AssertionError('getpgm command %s failed with errors "%s"' % (cmd, stderr))

--- a/tests/smdb/eventsummary_test.py
+++ b/tests/smdb/eventsummary_test.py
@@ -26,36 +26,53 @@ def test_eventsummary():
 
     # test flatfile
     flatfile = event.get_flatfile_dataframe().to_dict(into=OrderedDict)
-    assert flatfile['MODY'][0] == '0206'
-    assert flatfile['MODY'][4] == '0206'
-    assert flatfile['MODY'][8] == '0206'
-    assert flatfile['MODY'][12] == '1113'
-    assert flatfile['MODY'][18] == '0124'
-    assert flatfile['Station Name'][0] == 'Anshuo'
-    assert flatfile['Station Name'][4] == 'Chulu'
-    assert flatfile['Station Name'][8] == 'Donghe'
-    assert flatfile['Station Name'][12] == 'Te_Mara_Farm_Waiau'
-    assert flatfile['Station Name'][18] == ''
-    assert flatfile['Station ID  No.'][0] == 'EAS'
-    assert flatfile['Station ID  No.'][4] == 'ECU'
-    assert flatfile['Station ID  No.'][8] == 'EDH'
-    assert flatfile['Station ID  No.'][12] == 'WTMC'
-    assert flatfile['Station ID  No.'][18] == 'AOM001'
-    assert flatfile['Station Latitude'][0] == 22.381
-    assert flatfile['Station Latitude'][4] == 22.860
-    assert flatfile['Station Latitude'][8] == 22.972
-    assert flatfile['Station Latitude'][18] == 41.5267
-    assert flatfile['Station Longitude'][0] == 120.857
-    assert flatfile['Station Longitude'][4] == 121.092
-    assert flatfile['Station Longitude'][8] == 121.305
-    assert flatfile['Station Longitude'][18] == 140.9244
+    target_modys = np.sort(np.asarray(['0206', '0206', '0206', '0206', '0206',
+            '0206', '0206', '0206', '0206', '0206', '0206', '0206', '1113',
+            '1113', '1113', '1113', '0124', '0124', '0124', '0124']))
+    mody = flatfile['MODY']
+    modys = np.sort(np.asarray([mody[key] for key in mody]))
+    np.testing.assert_array_equal(modys, target_modys)
+    target_names = np.sort(np.asarray(['Anshuo', 'Anshuo', 'Anshuo', 'Anshuo',
+            'Chulu', 'Chulu', 'Chulu', 'Chulu', 'Donghe', 'Donghe', 'Donghe',
+            'Donghe', 'Te_Mara_Farm_Waiau', 'Te_Mara_Farm_Waiau',
+            'Te_Mara_Farm_Waiau', 'Te_Mara_Farm_Waiau', '', '', '', '']))
+    name = flatfile['Station Name']
+    names = np.sort(np.asarray([name[key] for key in name]))
+    np.testing.assert_array_equal(names, target_names)
+    target_ids = np.sort(np.asarray(['EAS', 'EAS', 'EAS', 'EAS', 'ECU', 'ECU',
+            'ECU', 'ECU', 'EDH', 'EDH', 'EDH', 'EDH', 'WTMC', 'WTMC', 'WTMC',
+            'WTMC', 'AOM001', 'AOM001', 'AOM001', 'AOM001']))
+    st_id = flatfile['Station ID  No.']
+    ids = np.sort(np.asarray([st_id[key] for key in st_id]))
 
+    para_dict = event.get_parametric(event.corrected_streams[0])
+    target_top = np.sort(np.asarray(['type', 'geometry', 'properties']))
+    top_keys = [key for key in para_dict]
+    np.testing.assert_array_equal(np.sort(top_keys), target_top)
+    target_properties = np.sort(np.asarray(['channels', 'process_time',
+            'pgms']))
+    property_keys = [key for key in para_dict['properties']]
+    np.testing.assert_array_equal(np.sort(property_keys), target_properties)
+    target_geometry = np.sort(np.asarray(['type', 'coordinates']))
+    geometry_keys = [key for key in para_dict['geometry']]
+    np.testing.assert_array_equal(np.sort(geometry_keys), target_geometry)
+    target_channel = np.asarray(['stats'])
+    channel_keys = [key for key in para_dict['properties']['channels']['H1']]
+    np.testing.assert_array_equal(np.sort(channel_keys), target_channel)
     try:
         event.get_station_dataframe('INVALID')
         success = True
     except KeyError:
         success = False
     assert success == False
+    length_before = len(event.corrected_streams)
+    event.corrected_streams = []
+    length_after = len(event.corrected_streams)
+    assert length_after == length_before
+    length_before = len(event.uncorrected_streams)
+    event.uncorrected_streams = []
+    length_after = len(event.uncorrected_streams)
+    assert length_after == length_before
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Parametric data can be written as a json file. Time series can be written in any [obspy write format](https://docs.obspy.org/packages/autogen/obspy.core.stream.Stream.write.html). For `getpgm` there is now the option to write parametric data and time series as miniseed. Parametric data fields need to be added for rupture and distances once they are available.